### PR TITLE
No longer bundle `goog.json.EvalJsonProcessor` in order to support la…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- No longer bundle `goog.json.EvalJsonProcessor` in order to support latest Closure Library.
 
 ## [2.14.0] - 2018-05-02
 ### Added

--- a/planck-cljs/src/planck/bundle.cljs
+++ b/planck-cljs/src/planck/bundle.cljs
@@ -92,7 +92,6 @@
    [goog.iter.Iterable]
    [goog.iter.Iterator]
    [goog.json]
-   [goog.json.EvalJsonProcessor]
    [goog.json.NativeJsonProcessor]
    [goog.json.Replacer]
    [goog.json.Reviver]


### PR DESCRIPTION
…test Closure Library