### PR TITLE
Read the environment variables into planck.environ/env

### DIFF
--- a/planck-c/engine.c
+++ b/planck-c/engine.c
@@ -503,6 +503,8 @@ void *do_engine_init(void *data) {
 
     register_global_function(ctx, "PLANCK_SIGNAL_TASK_COMPLETE", function_signal_task_complete);
 
+    register_global_function(ctx, "PLANCK_GETENV", function_getenv);
+
     display_launch_timing("register fns");
 
     // Monkey patch cljs.core/system-time to use Planck's high-res timer

--- a/planck-c/functions.h
+++ b/planck-c/functions.h
@@ -150,3 +150,6 @@ JSValueRef function_sleep(JSContextRef ctx, JSObjectRef function, JSObjectRef th
 
 JSValueRef function_signal_task_complete(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
                                          size_t argc, const JSValueRef args[], JSValueRef *exception);
+
+JSValueRef function_getenv(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+                           size_t argc, const JSValueRef args[], JSValueRef *exception);

--- a/planck-cljs/src/planck/environ.cljs
+++ b/planck-cljs/src/planck/environ.cljs
@@ -1,0 +1,3 @@
+(ns planck.environ)
+
+(defonce env (js->clj (js/PLANCK_GETENV)))

--- a/planck-cljs/test/planck/environ_test.cljs
+++ b/planck-cljs/test/planck/environ_test.cljs
@@ -1,0 +1,10 @@
+(ns planck.environ-test
+  (:require [planck.environ :refer env]
+            [planck.io :as io]
+            [clojure.string :as string]
+            [cljs.test :refer-macros [deftest is use-fixtures]]))
+
+(deftest user-home
+  (is (and (#{"HOME"} (keys env))
+           (not (string/blank? (get env "HOME")))
+           (io/directory? (get env "HOME")))))


### PR DESCRIPTION
I needed to access my `$HOME` folder for some local scripting and saw that #165 was still up there. Here's my take at exposing the environment to a planck script:

- added `js/PLANCK_GETENV` to retrieve either the full environment or single
environment variables
- added `planck.environ/env` to revrieve the environment in user code