### PR TITLE
Trailing comma error with optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. This change
 - Cache behavior when executing standalone script with shebang deps ([#749](https://github.com/mfikes/planck/issues/749))
 - Fix build issue when using `xxdi.pl` ([#770](https://github.com/mfikes/planck/issues/770))
 - Fix loading of Closure libs
+- Trailing comma error with optimizations ([#781](https://github.com/mfikes/planck/issues/781))
 
 ## [2.17.0] - 2018-07-02
 ### Changed

--- a/planck-cljs/src/planck/closure.cljs
+++ b/planck-cljs/src/planck/closure.cljs
@@ -14,7 +14,7 @@
                      :compilationLevel         (case optimizations
                                                  :simple "SIMPLE"
                                                  :whitespace "WHITESPACE_ONLY")
-                     :languageIn               "ECMASCRIPT3"
+                     :languageIn               "ECMASCRIPT5"
                      :languageOut              "ECMASCRIPT3"
                      :processClosurePrimitives false
                      :createSourceMap          (some? sm-data)


### PR DESCRIPTION
Update language-in to ES5.
This makes things consistent with ClojureScript as well.

Fixes #781