### PR TITLE
Support IPrintWithWriter on native types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. This change
 ### Changed
 - Updates for private var use in Planck namespaces
 - Ensure all earmuffed vars defined in Planck namespaces are dynamic
+- Support `IPrintWithWriter` on native types ([#767](https://github.com/planck-repl/planck/issues/767))
 
 ### Fixed
 - Cache behavior when executing standalone script with shebang deps ([#749](https://github.com/mfikes/planck/issues/749))


### PR DESCRIPTION
This may not handle all cases correctly, but it certainly allows the
users to define how native objects and arrays are printed.

Fixes #767