### PR TITLE
Check for and return undefined in get_value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. This change
 ### Fixed
 - Make s/explain provide names of core fns ([#832](https://github.com/mfikes/planck/issues/832))
 - Analysis cache issue with `load-file` ([#843](https://github.com/mfikes/planck/issues/843))
+- Check for handle undefined values in C code that fetches values from JavaScriptCore
 
 ## [2.19.0] - 2018-11-02
 ### Changed

--- a/planck-c/engine.c
+++ b/planck-c/engine.c
@@ -156,6 +156,9 @@ JSValueRef get_value(JSContextRef ctx, char *namespace, char *name) {
     while (ns_part != NULL) {
         char *munged_ns_part = munge(ns_part);
         if (ns_val) {
+            if (JSValueIsUndefined(ctx, ns_val)) {
+                return ns_val;
+            }
             ns_val = get_value_on_object(ctx, JSValueToObject(ctx, ns_val, NULL), munged_ns_part);
         } else {
             ns_val = get_value_on_object(ctx, JSContextGetGlobalObject(ctx), munged_ns_part);


### PR DESCRIPTION
This will lead to a better error message.
(Otherwise a crash will result.)