### PR TITLE
Replace all references to 'accepts' with 'accept'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- Consistent use of 'accept' in `planck.http` ([#837](https://github.com/planck-repl/planck/issues/837))
 
 ## [2.20.0] - 2019-01-31
 ### Added

--- a/planck-cljs/src/planck/http.cljs
+++ b/planck-cljs/src/planck/http.cljs
@@ -54,7 +54,7 @@
         client)
       (client request))))
 
-(defn- wrap-accepts
+(defn- wrap-accept
   "Set the appropriate Accept header."
   [client]
   (fn [request]
@@ -165,7 +165,7 @@
      wrap-to-from-js
      wrap-throw-on-error
      wrap-debug
-     wrap-accepts
+     wrap-accept
      wrap-content-type
      wrap-add-content-length
      wrap-form-params
@@ -180,7 +180,7 @@
   :timeout, number, default 5 seconds
   :debug, boolean, assoc the request on to the response
   :insecure, proceed even if the connection is considered insecure
-  :accepts, keyword or string. Valid keywords are :json or :xml
+  :accept, keyword or string. Valid keywords are :json or :xml
   :content-type, keyword or string Valid keywords are :json or :xml
   :headers, map, a map containing headers
   :user-agent, string, the user agent header to send
@@ -194,7 +194,7 @@
 (s/def ::timeout integer?)
 (s/def ::debug boolean?)
 (s/def ::insecure boolean?)
-(s/def ::accepts (s/or :kw #{:json :xml} :str string?))
+(s/def ::accept (s/or :kw #{:json :xml} :str string?))
 (s/def ::content-type (s/or :kw #{:json :xml} :str string?))
 (s/def ::headers (s/and map? (fn [m]
                                (and (every? keyword? (keys m))
@@ -209,7 +209,7 @@
 
 (s/fdef get
   :args (s/cat :url string? :opts (s/? (s/keys :opt-un
-                                               [::timeout ::debug ::accepts ::content-type ::headers ::socket
+                                               [::timeout ::debug ::accept ::content-type ::headers ::socket
                                                 ::binary-response ::insecure ::user-agent ::follow-redirects ::max-redirects])))
   :ret (s/keys :req-un [::body ::headers ::status]))
 
@@ -259,7 +259,7 @@
 (s/def ::multipart-params seq?)
 
 (s/fdef post
-  :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::accepts ::content-type ::headers ::body
+  :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::accept ::content-type ::headers ::body
                                                         ::form-params ::multipart-params ::socket ::insecure ::user-agent])))
   :ret (s/keys :req-un [::body ::headers ::status]))
 
@@ -274,7 +274,7 @@
   ([url opts] (request js/PLANCK_REQUEST :put url opts)))
 
 (s/fdef put
-  :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::accepts ::content-type ::headers ::body
+  :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::accept ::content-type ::headers ::body
                                                         ::form-params ::multipart-params ::socket ::insecure ::user-agent])))
   :ret (s/keys :req-un [::body ::headers ::status]))
 
@@ -289,6 +289,6 @@
   ([url opts] (request js/PLANCK_REQUEST :patch url opts)))
 
 (s/fdef patch
-  :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::accepts ::content-type ::headers ::body
+  :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::accept ::content-type ::headers ::body
                                                         ::form-params ::multipart-params ::socket ::insecure ::user-agent])))
   :ret (s/keys :req-un [::body ::headers ::status]))

--- a/planck-cljs/test/planck/http_test.cljs
+++ b/planck-cljs/test/planck/http_test.cljs
@@ -63,13 +63,13 @@
                  ((#'http/wrap-content-type identity))
                  (get-in [:headers "Content-Type"]))))))
 
-(deftest wrap-accepts-test
+(deftest wrap-accept-test
   (testing "wrap-accept"
     (is (= "application/json" (-> {:accept :json}
-                                ((#'http/wrap-accepts identity))
+                                ((#'http/wrap-accept identity))
                                 (get-in [:headers "Accept"]))))
     (is (= nil (-> {:accept :json}
-                 ((#'http/wrap-accepts identity))
+                 ((#'http/wrap-accept identity))
                  :accept)))))
 
 (deftest wrap-content-length-test

--- a/site/src/planck-http.md
+++ b/site/src/planck-http.md
@@ -20,7 +20,7 @@ _Vars_
   `:timeout`, number, default 5 seconds<br/>
   `:debug`, boolean, assoc the request on to the response<br/>
   `:insecure`, proceed even if the connection is considered insecure<br/>
-  `:accepts`, keyword or string. Valid keywords are `:json` or `:xml`<br/>
+  `:accept`, keyword or string. Valid keywords are `:json` or `:xml`<br/>
   `:content-type`, keyword or string Valid keywords are `:json` or `:xml`<br/>
   `:headers`, map, a map containing headers<br/>
   `:user-agent`, string, the user agent header to send<br/>
@@ -30,7 +30,7 @@ _Vars_
   `:binary-response`, boolean, encode response body as vector of unsigned bytes
 
 Spec<br/>
- _args_: `(cat :url string? :opts (? (keys :opt-un  [::timeout ::debug ::accepts ::content-type ::headers ::socket ::binary-response ::insecure ::user-agent ::follow-redirects ::max-redirects])))`<br/>
+ _args_: `(cat :url string? :opts (? (keys :opt-un  [::timeout ::debug ::accept ::content-type ::headers ::socket ::binary-response ::insecure ::user-agent ::follow-redirects ::max-redirects])))`<br/>
  _ret_: `(keys :req-un [::body ::headers ::status])`
 
 ### <a name="head"></a>head
@@ -73,7 +73,7 @@ Spec<br/>
 `["name" ["content" "filename"]]`<br/>
 
 Spec<br/>
- _args_: `(cat :url string? :opts (? (keys :opt-un [::timeout ::debug ::accepts ::content-type ::headers ::body ::form-params ::multipart-params ::socket ::user-agent])))`<br/>
+ _args_: `(cat :url string? :opts (? (keys :opt-un [::timeout ::debug ::accept ::content-type ::headers ::body ::form-params ::multipart-params ::socket ::user-agent])))`<br/>
  _ret_: `(keys :req-un [::body ::headers ::status ::insecure])`
 
 ### <a name="put"></a>put
@@ -87,7 +87,7 @@ Spec<br/>
 `["name" ["content" "filename"]]`<br/>
 
 Spec<br/>
- _args_: `(cat :url string? :opts (? (keys :opt-un [::timeout ::debug ::accepts ::content-type ::headers ::body ::form-params ::multipart-params ::socket ::user-agent])))`<br/>
+ _args_: `(cat :url string? :opts (? (keys :opt-un [::timeout ::debug ::accept ::content-type ::headers ::body ::form-params ::multipart-params ::socket ::user-agent])))`<br/>
  _ret_: `(keys :req-un [::body ::headers ::status ::insecure])`
 
 ### <a name="patch"></a>patch
@@ -101,5 +101,5 @@ Spec<br/>
 `["name" ["content" "filename"]]`<br/>
 
 Spec<br/>
- _args_: `(cat :url string? :opts (? (keys :opt-un [::timeout ::debug ::accepts ::content-type ::headers ::body ::form-params ::multipart-params ::socket ::insecure ::user-agent])))`<br/>
+ _args_: `(cat :url string? :opts (? (keys :opt-un [::timeout ::debug ::accept ::content-type ::headers ::body ::form-params ::multipart-params ::socket ::insecure ::user-agent])))`<br/>
  _ret_: `(keys :req-un [::body ::headers ::status])`


### PR DESCRIPTION
The `planck.http` library allows a user to set the ACCEPT header in HTTP requests. However, the library currently refers to the option to set this header, as well as related functions, using the word 'accepts' rather than 'accept' (see #837).

This PR replaces all references to 'accepts' with 'accept'. It is arguable whether these changes represent a breaking change. Planck's documentation previously said that `planck.http/get` (and by extension `patch`, `post` and `put`) could be passed an `opts` map with an `:accepts` key. However, the private functions within `planck.http/get` always used `:accept` as the key so one could view this as a bug fix rather than a change to the API.

The tests and documentation for `plank.http/get` have also been updated.