### PR TITLE
planck.core/load-string evaluates in current namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. This change
 
 ### Fixed
 - Consistent use of 'accept' in `planck.http` ([#837](https://github.com/planck-repl/planck/issues/837))
+- `planck.core/load-string` evaluates in current namespace ([#867](https://github.com/planck-repl/planck/issues/867))
 
 ## [2.20.0] - 2019-01-31
 ### Added

--- a/planck-cljs/src/planck/core.cljs
+++ b/planck-cljs/src/planck/core.cljs
@@ -467,13 +467,13 @@
   :args (s/alt :unary (s/cat :millis #(and (integer? %) (not (neg? %))))
                :binary (s/cat :millis #(and (integer? %) (not (neg? %))) :nanos #(and (integer? %) (<= 0 % 999999)))))
 
+(declare load-string)
+
 (defn load-reader
   "Sequentially read and evaluate the set of forms contained in the
   stream/file"
   [rdr]
-  (->> (repeatedly #(read {:eof ::eof} rdr))
-    (take-while #(not (keyword-identical? % ::eof)))
-    (reduce #(eval %2) nil)))
+  (load-string (slurp rdr)))
 
 (s/fdef load-reader
   :args (s/cat :rdr #(satisfies? IPushbackReader %))
@@ -483,7 +483,7 @@
   "Sequentially read and evaluate the set of forms contained in the
   string"
   [s]
-  (load-reader (make-string-reader s)))
+  (#'repl/load-string s))
 
 (s/fdef load-string
   :args (s/cat :s string?)

--- a/planck-cljs/test/planck/core_test.cljs
+++ b/planck-cljs/test/planck/core_test.cljs
@@ -145,7 +145,11 @@
 
 (deftest load-string-test
   (is (= 3 (planck.core/load-string "1 2 3")))
-  (is (= "hi" (with-out-str (planck.core/load-string "1 (print \"hi\") 2")))))
+  (is (= "hi" (with-out-str (planck.core/load-string "1 (print \"hi\") 2"))))
+  (is (= :foo.core/x (planck.core/load-string "(ns foo.core) ::x"))))
+
+(deftest load-reader-test
+  (is (= 3 (planck.core/load-reader (#'planck.core/make-string-reader "1 2 3")))))
 
 (deftest requiring-resolve-test
   (is (nil? (planck.core/resolve 'planck.requiring-resolve-ns/a)))


### PR DESCRIPTION
Fixes #867