### PR TITLE
Document using Boot to generate a classpath file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
-## [2.21.0] - 2019-02-24
+## [2.21.0] - 2019-03-07
 ### Added
 - Add `planck.io/exists?`, `planck.io/hidden-file?`, `planck.io/regular-file?`, `planck.io/symbolic-link?` ([#863](https://github.com/planck-repl/planck/issues/863))
 - Add `planck.io/path-elements`, `planck.io/file-name`
+- Document using Boot to generate a classpath file ([#343](https://github.com/planck-repl/planck/issues/343))
 
 ### Changed
 * Update to ClojureScript 1.10.520

--- a/site/src/dependencies.md
+++ b/site/src/dependencies.md
@@ -44,6 +44,22 @@ This stand-alone script specifies its own dependencies (via the `-Sdeps` _dep-op
 
 > Also note that the script both a valid Bash script (as the `exec` causes the script to terminate prior to any ClojureScript text being parsed), and a valid ClojureScript file (all of the values on `"exec"` line are ClojureScript strings and thus harmless values preceding the `require` form).
 
+### Using Boot
+
+The [Boot](https://boot-clj.com/) build tool can be used to generate a classpath file that can be fed into Planck. A side effect of creating such a file is that Boot will also download the specified dependencies (see "Downloading Deps" below).
+
+Let's look at an example that puts the [cljs-time](https://clojars.org/com.andrewmcveigh/cljs-time) library on the classpath. On a system with `boot` installed, run the following:
+
+```sh
+boot -d com.andrewmcveigh/cljs-time:"0.5.2" with-cp -w --file .classpath
+```
+
+The list of dependencies (one in this case) is written to `.classpath`. You can use this file in invocations of `planck` like so:
+
+```sh
+planck -c `cat .classpath` 
+```
+
 ### Classpath Specification
 
 Planck's classpath can be directly specified by providing a colon-separated list of directories and/or JARs via the `-c` / `-​-​classpath` argument, or by the `PLANCK_CLASSPATH` environment variable.


### PR DESCRIPTION
Planck can access dependencies that are specified on its classpath. These can be specified by hand but an alternative is to use a tool like Boot to output the dependencies to a file that can then be fed into Planck. This PR adds documentation to the Planck docs that explains how this can be done and closes #343.

It's noted that, due to the introduction of tools.deps and Planck's support for it via `plk`, this is less important than it was at the time of the initial discussion.