### PR TITLE
Document `planck.io/resource`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. This change
 ### Added
 - Add `planck.io/exists?`, `planck.io/hidden-file?`, `planck.io/regular-file?`, `planck.io/symbolic-link?` ([#863](https://github.com/planck-repl/planck/issues/863))
 - Add `planck.io/path-elements`, `planck.io/file-name`
+- Document `planck.io/resource` ([#487](https://github.com/planck-repl/planck/issues/487))`
 
 ### Changed
 * Update to ClojureScript 1.10.520

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [2.21.0] - 2019-02-24
 ### Added
 - Add `planck.io/exists?`, `planck.io/hidden-file?`, `planck.io/regular-file?`, `planck.io/symbolic-link?` ([#863](https://github.com/planck-repl/planck/issues/863))
 - Add `planck.io/path-elements`, `planck.io/file-name`
@@ -783,7 +785,8 @@ All notable changes to this project will be documented in this file. This change
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/mfikes/planck/compare/2.20.0...HEAD
+[Unreleased]: https://github.com/mfikes/planck/compare/2.21.0...HEAD
+[2.21.0]: https://github.com/mfikes/planck/compare/2.20.0...2.21.0
 [2.20.0]: https://github.com/mfikes/planck/compare/2.19.1...2.20.0
 [2.19.0]: https://github.com/mfikes/planck/compare/2.18.1...2.19.0
 [2.18.1]: https://github.com/mfikes/planck/compare/2.18.0...2.18.1

--- a/planck-c/globals.h
+++ b/planck-c/globals.h
@@ -1,6 +1,6 @@
 // Global variables used throughout Planck
 
-#define PLANCK_VERSION "2.20.0"
+#define PLANCK_VERSION "2.21.0"
 
 // Configuration
 

--- a/planck-cljs/src/planck/io.cljs
+++ b/planck-cljs/src/planck/io.cljs
@@ -418,7 +418,13 @@
   :ret (s/coll-of file?))
 
 (defn resource
-  "Returns the URI for a named resource."
+  "Returns the URI for the named resource, `n`.
+  
+  The resource must be either a JAR resource, a file resource or a \"bundled\"
+  resource. JARs and files are expressed relative to the classpath while 
+  \"bundled\" resources are the namespaces bundled with Planck and are referred 
+  to by reference to the file that contains the namespace, eg. `cljs.test` is 
+  \"cljs/test.cljs\"."
   [n]
   (when-some [[_ _ loaded-path loaded-type loaded-location] (js/PLANCK_LOAD n)]
     (case loaded-type

--- a/site/src/planck-io.md
+++ b/site/src/planck-io.md
@@ -287,8 +287,8 @@ Returns the URI for the named resource, `n`.
 The resource must be either a JAR resource, a file resource or a "bundled" resource. JARs and files are expressed relative to the classpath while "bundled" resources are the namespaces bundled with Planck and are referred to by reference to the file that contains the namespace, eg. `cljs.test` is `"cljs/test.cljs"`.
 
 Spec<br/>
- _args_: `(cat :n string?)`<br/>
- _ret_: `Uri?`<br/>
+ _args_: `(cat :n (nilable string?))`<br/>
+ _ret_: `(nilable (instance? Uri %))`<br/>
 
 ### <a name="symbolic-link?"></a>symbolic-link?
 `([f])`

--- a/site/src/planck-io.md
+++ b/site/src/planck-io.md
@@ -36,6 +36,7 @@ _Vars_
 [path-elements](#path-elements)<br/>
 [reader](#reader)<br/>
 [regular-file?](#regular-file?)<br/>
+[resource](#resource)<br/>
 [symbolic-link?](#symbolic-link?)<br/>
 [writer](#writer)<br/>
    
@@ -277,6 +278,17 @@ Checks if `f` is a regular file.
 Spec<br/>
  _args_: `(cat :f (or :string string? :file file?))`<br/>
  _ret_: `boolean?`<br/>
+
+### <a name="resource"></a>resource
+`([n])`
+
+Returns the URI for the named resource, `n`.
+  
+The resource must be either a JAR resource, a file resource or a "bundled" resource. JARs and files are expressed relative to the classpath while "bundled" resources are the namespaces bundled with Planck and are referred to by reference to the file that contains the namespace, eg. `cljs.test` is `"cljs/test.cljs"`.
+
+Spec<br/>
+ _args_: `(cat :n string?)`<br/>
+ _ret_: `Uri?`<br/>
 
 ### <a name="symbolic-link?"></a>symbolic-link?
 `([f])`


### PR DESCRIPTION
Planck includes the function `planck.io/resource` for determining the URI of a resource. It is similar to `clojure.java.io/resource`.

While `planck.io/resource` has been part of Planck since version 2.3.0, no documentation had been added to the SDK and the docstring offered only a brief description. This commit provides more fulsome documentation. It closes #487.