### PR TITLE
Support interning quoted data structures (#508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file. This change
 ### Added
 - Add `planck.core/with-in-str` ([#873](https://github.com/planck-repl/planck/issues/873))
 
+### Fixed
+- Support interning quoted data structues ([#508](https://github.com/planck-repl/planck/issues/508))
+
 ## [2.21.0] - 2019-03-07
 ### Added
 - Add `planck.io/exists?`, `planck.io/hidden-file?`, `planck.io/regular-file?`, `planck.io/symbolic-link?` ([#863](https://github.com/planck-repl/planck/issues/863))

--- a/planck-cljs/src/planck/repl.cljs
+++ b/planck-cljs/src/planck/repl.cljs
@@ -2200,7 +2200,7 @@
      (eval `(def ~name) (ns-name the-ns))))
   ([ns name val]
    (when-let [the-ns (find-ns (cond-> ns (instance? Namespace ns) ns-name))]
-     (eval `(def ~name ~val) (ns-name the-ns)))))
+     (eval `(def ~name (quote ~val)) (ns-name the-ns)))))
 
 (defn- ^:export wrap-color-err
   []

--- a/planck-cljs/test/planck/core_test.cljs
+++ b/planck-cljs/test/planck/core_test.cljs
@@ -57,13 +57,17 @@
 
 (planck.core/intern 'foo.core 'a 3)
 (planck.core/intern 'foo.core (with-meta 'b {:alpha 17}) 12)
-(planck.core/intern (find-ns 'foo.core) 'd 18)
+(planck.core/intern (find-ns 'foo.core) 'c 18)
+(planck.core/intern 'foo.core 'd 'bar)
+(planck.core/intern 'foo.core 'e '[bar])
 
 (deftest test-intern
-  (is (= 4 (count (planck.core/eval '(ns-interns (quote foo.core))))))
+  (is (= 6 (count (planck.core/eval '(ns-interns (quote foo.core))))))
   (is (= 12 @(planck.core/ns-resolve 'foo.core 'b)))
   (is (= 17 (:alpha (meta (planck.core/ns-resolve 'foo.core 'b)))))
-  (is (= 18 @(planck.core/ns-resolve 'foo.core 'd))))
+  (is (= 18 @(planck.core/ns-resolve 'foo.core 'c)))
+  (is (= 'bar @(planck.core/ns-resolve 'foo.core 'd)))
+  (is (= '[bar] @(planck.core/ns-resolve 'foo.core 'e))))
 
 (defn spit-slurp [file-name content]
   (planck.core/spit file-name content)


### PR DESCRIPTION
Planck provides an `intern` function in `planck.core` that is similar to Clojure's `clojure.core/intern`. Whereas Clojure's version calls out to a Java class, Planck `eval`s a `def` form defining the name and value to be interned.

The prior implementation in Planck used syntax quoting to generate the `def` form. The problem with this was that certain data structures that would be passed to `planck.core/intern` as a quoted argument would be unquoted in the `def` form. Depending on the data structure, this could then cause an error.

A simple example that demonstrates the problem is passing a symbol as the value to be bound. Calling `(planck.core/intern *ns* 'foo 'bar)` would result in one of two things, both of which were wrong. If `bar` were not bound, Planck would report an error when `bar` was unquoted because no value existed. If `bar` were bound, that value would be interpolated. In neither case would `foo` be bound to the symbol `bar`.

This PR adds support for quoted data structures by quoting any value that is passed to `planck.core/intern`. This takes advantage of the fact that quoting has no effect on most data structures. For example, `'5` results in `5`. This closes #508.