### PR TITLE
Fix single-character single-segment namespace crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. This change
 - Fix error messages in `planck.io` ([#582](https://github.com/planck-repl/planck/issues/582))
 - Bad import taints analysis metadata ([#888](https://github.com/planck-repl/planck/issues/888))
 - Long form needed with plk for optimizations / checked arrays ([#750](https://github.com/planck-repl/planck/issues/750))
+- Crash when defining single segment ns ([#588](https://github.com/planck-repl/planck/issues/588))
 
 ## [2.21.0] - 2019-03-07
 ### Added

--- a/planck-c/repl.c
+++ b/planck-c/repl.c
@@ -54,25 +54,29 @@ void empty_previous_lines(repl_t *repl) {
 }
 
 char *form_prompt(repl_t *repl, bool is_secondary) {
-
     char *prompt = NULL;
+    char *sec_prompt = "#_=> ";
+    size_t prompt_min_len = 6; // length of sec_prompt literal
+    size_t prefix_min_len = 2; // length of "#_" prefix
 
     char *current_ns = repl->current_ns;
     bool dumb_terminal = repl->session_id != 0 || config.dumb_terminal;
 
     if (!is_secondary) {
-        if (strlen(current_ns) == 1 && !config.dumb_terminal) {
-            prompt = malloc(6 * sizeof(char));
+        if (strlen(current_ns) < prefix_min_len && !config.dumb_terminal) {
+            prompt = malloc(prompt_min_len * sizeof(char));
             sprintf(prompt, " %s=> ", current_ns);
         } else {
             prompt = str_concat(current_ns, "=> ");
         }
     } else {
         if (!dumb_terminal) {
-            size_t len = strlen(current_ns) - 2;
-            prompt = malloc((len + 6) * sizeof(char));
-            memset(prompt, ' ', len);
-            sprintf(prompt + len, "#_=> ");
+            size_t ns_len = strlen(current_ns);
+            size_t ns_len_extra = (ns_len < prefix_min_len) ?
+                                      0 : ns_len - prefix_min_len;
+            prompt = malloc((prompt_min_len + ns_len_extra) * sizeof(char));
+            memset(prompt, ' ', ns_len_extra);
+            sprintf(prompt + ns_len_extra, sec_prompt);
         }
     }
 


### PR DESCRIPTION
The Planck REPL provides for multiline input with automatic indentation for subsequent lines. This is achieved using the Linenoise library. When defining a prompt using Linenoise, a secondary prompt is provided to display on subsequent lines. Planck's secondary prompt is "#_=>". This results in an expected minimum width for any Clojure namespace being displayed at the REPL as two characters.

The `form_prompt()` function in `repl.c` contained an arithmetic operation that resulted in a negative value if the first operand (representing the length of the namespace) was less than 2 (as discussed in #588). This PR tests for that condition and provides that the result cannot be less than zero. It also renames some of the variables used for clarity.

This fixes #588.