### PR TITLE
Improve build caching by deleting stale files

### DIFF
--- a/planck-cljs/script/bundle
+++ b/planck-cljs/script/bundle
@@ -119,6 +119,8 @@ then
       fi
     fi
     cp $file.optim $file
+    rm -f $buildcache/$file.*.optim
+    rm -f $buildcache/$file.*.map
     cp $file.optim $buildcache/$file.$crc.optim
     cp $file.map $buildcache/$file.$crc.map # Optimised maps are never cached
   else
@@ -137,8 +139,9 @@ then
   if [ ! -f $buildcache/$file.$crc.aot ]
   then
     ../../planck-c/build/planck ../script/decode.cljs $file > $file.aot
-    cp $file.aot $buildcache/$file.$crc.aot
     cp $file.aot $file
+    rm -f $buildcache/$file.*.aot
+    cp $file.aot $buildcache/$file.$crc.aot
   else
     cp $buildcache/$file.$crc.aot $file
   fi


### PR DESCRIPTION
Planck caches intermediate files used for optimised builds. Cached files are stored with a filename that includes the SHA checksum of the "source" file. In future compilations, this checksum is used to determine if the file in the cache is stale.

The source file in this instance is always a JavaScript file. For sources that are written in ClojureScript, the file that is used is the generated JavaScript file. While a simple ClojureScript file will generate the same JavaScript every time, this is not the case if the ClojureScript file uses macros that include autogenerated symbols. These symbols will differ every time which will cause the generated JavaScript to differ every time which will cause the SHA checksum to differ every time and which will cause a new cache file to be generated every time. The result will be a cache littered with stale files.

To avoid this problem, this commit deletes any existing cache files for the given source file before saving the compiled file to the cache. This has the disadvantage of requiring recompilation if the changes to a source file are reverted to an earlier version that had been previously compiled. However, given the relatively infrequency of these occurrences, this is considered an acceptable trade-off.