### PR TITLE
A tty? function to use in scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- Add `planck.io/tty?` ([#911](https://github.com/planck-repl/planck/issues/911))
 
 ## [2.22.0] - 2019-04-06
 ### Added

--- a/int-test/expected/PLANCK-OUT.txt
+++ b/int-test/expected/PLANCK-OUT.txt
@@ -619,3 +619,5 @@ stdout non-TTY is detected (in a pipeline)
 [*out* false]
 stderr non-TTY is detected (redirected to /dev/null)
 [*err* false]
+*err* TTY is detected when rebound to *out* even when stderr is redirected to /dev/null
+[[*out* true] [*err* true]]

--- a/int-test/expected/PLANCK-OUT.txt
+++ b/int-test/expected/PLANCK-OUT.txt
@@ -611,3 +611,11 @@ Execution error (ReferenceError) at (<cljs repl>:1).
 Can't find variable: a
 Auto-load user.cljs
 3
+stdio TTY is detected (in a faketty)
+[[*in* true] [*out* true] [*err* true]]
+stdin non-TTY is detected (in a pipeline)
+[*in* false]
+stdout non-TTY is detected (in a pipeline)
+[*out* false]
+stderr non-TTY is detected (redirected to /dev/null)
+[*err* false]

--- a/int-test/script/gen-actual
+++ b/int-test/script/gen-actual
@@ -818,3 +818,12 @@ echo
 echo "stderr non-TTY is detected (redirected to /dev/null)"
 $PLANCK -i $SRC/test_tty/stderr.cljs 2>/dev/null
 echo
+
+echo "*err* TTY is detected when rebound to *out* even when stderr is redirected to /dev/null"
+cat <<EOF >/tmp/PLANCK_TTY_REBINDING_TEST
+#!/bin/sh
+$PLANCK -i $SRC/test_tty/rebinding_err_out.cljs 2>/dev/null
+EOF
+chmod +x /tmp/PLANCK_TTY_REBINDING_TEST
+faketty /tmp/PLANCK_TTY_REBINDING_TEST
+echo

--- a/int-test/script/gen-actual
+++ b/int-test/script/gen-actual
@@ -797,7 +797,11 @@ x
 REPL_INPUT
 
 faketty () {
-    script -qfec "$(printf "%q " "$@")"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        script -qt 0 /dev/null $@
+    else
+        script -qfec "$(printf "%q " "$@")" /dev/null
+    fi
 }
 echo "stdio TTY is detected (in a faketty)"
 faketty $PLANCK -i $SRC/test_tty/stdio.cljs

--- a/int-test/script/gen-actual
+++ b/int-test/script/gen-actual
@@ -795,3 +795,22 @@ echo "(def x 3)" > /tmp/PLANCK_SRC/user.cljs
 $PLANCK -c /tmp/PLANCK_SRC <<REPL_INPUT
 x
 REPL_INPUT
+
+faketty () {
+    script -qfec "$(printf "%q " "$@")"
+}
+echo "stdio TTY is detected (in a faketty)"
+faketty $PLANCK -i $SRC/test_tty/stdio.cljs
+echo
+
+echo "stdin non-TTY is detected (in a pipeline)"
+echo "" | $PLANCK -i $SRC/test_tty/stdin.cljs
+echo
+
+echo "stdout non-TTY is detected (in a pipeline)"
+$PLANCK -i $SRC/test_tty/stdout.cljs | cat
+echo
+
+echo "stderr non-TTY is detected (redirected to /dev/null)"
+$PLANCK -i $SRC/test_tty/stderr.cljs 2>/dev/null
+echo

--- a/int-test/src/test_tty/rebinding_err_out.cljs
+++ b/int-test/src/test_tty/rebinding_err_out.cljs
@@ -1,0 +1,5 @@
+(require 'planck.core)
+(require 'planck.io)
+(binding [planck.core/*err* cljs.core/*out*]
+  (pr [['*out* (planck.io/tty? cljs.core/*out*)]
+       ['*err* (planck.io/tty? planck.core/*err*)]]))

--- a/int-test/src/test_tty/stderr.cljs
+++ b/int-test/src/test_tty/stderr.cljs
@@ -1,0 +1,3 @@
+(require 'planck.core)
+(require 'planck.io)
+(pr ['*err* (planck.io/tty? planck.core/*err*)])

--- a/int-test/src/test_tty/stdin.cljs
+++ b/int-test/src/test_tty/stdin.cljs
@@ -1,0 +1,3 @@
+(require 'planck.core)
+(require 'planck.io)
+(pr ['*in* (planck.io/tty? planck.core/*in*)])

--- a/int-test/src/test_tty/stdio.cljs
+++ b/int-test/src/test_tty/stdio.cljs
@@ -1,0 +1,5 @@
+(require 'planck.core)
+(require 'planck.io)
+(pr [['*in*  (planck.io/tty? planck.core/*in*)]
+     ['*out* (planck.io/tty? cljs.core/*out*)]
+     ['*err* (planck.io/tty? planck.core/*err*)]])

--- a/int-test/src/test_tty/stdout.cljs
+++ b/int-test/src/test_tty/stdout.cljs
@@ -1,0 +1,3 @@
+(require 'planck.core)
+(require 'planck.io)
+(pr ['*out* (planck.io/tty? cljs.core/*out*)])

--- a/planck-c/engine.c
+++ b/planck-c/engine.c
@@ -523,6 +523,8 @@ void *do_engine_init(void *data) {
 
     register_global_function(ctx, "PLANCK_GETENV", function_getenv);
 
+    register_global_function(ctx, "PLANCK_ISATTY", function_isatty);
+
     display_launch_timing("register fns");
 
     // Monkey patch cljs.core/system-time to use Planck's high-res timer

--- a/planck-c/functions.c
+++ b/planck-c/functions.c
@@ -1522,3 +1522,13 @@ JSValueRef function_getenv(JSContextRef ctx, JSObjectRef function, JSObjectRef t
   }
   return JSValueMakeNull(ctx);
 }
+
+JSValueRef function_isatty(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+                           size_t argc, const JSValueRef args[], JSValueRef *exception) {
+  if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeNumber) {
+    int fd = (int) JSValueToNumber(ctx, args[0], NULL);
+    int result = isatty(fd);
+    return JSValueMakeBoolean(ctx, (result != 0));
+  }
+  return JSValueMakeNull(ctx);
+}

--- a/planck-c/functions.c
+++ b/planck-c/functions.c
@@ -1527,8 +1527,13 @@ JSValueRef function_isatty(JSContextRef ctx, JSObjectRef function, JSObjectRef t
                            size_t argc, const JSValueRef args[], JSValueRef *exception) {
   if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeNumber) {
     int fd = (int) JSValueToNumber(ctx, args[0], NULL);
-    int result = isatty(fd);
-    return JSValueMakeBoolean(ctx, (result != 0));
+    if (fd >= 0) {
+      errno = 0;
+      bool result = isatty(fd);
+      if (errno != EBADF) {
+        return JSValueMakeBoolean(ctx, result);
+      }
+    }
   }
   return JSValueMakeNull(ctx);
 }

--- a/planck-c/functions.h
+++ b/planck-c/functions.h
@@ -156,3 +156,6 @@ JSValueRef function_signal_task_complete(JSContextRef ctx, JSObjectRef function,
 
 JSValueRef function_getenv(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
                            size_t argc, const JSValueRef args[], JSValueRef *exception);
+
+JSValueRef function_isatty(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+                           size_t argc, const JSValueRef args[], JSValueRef *exception);

--- a/planck-cljs/src/planck/core.cljs
+++ b/planck-cljs/src/planck/core.cljs
@@ -495,6 +495,14 @@
   :args (s/cat :s string?)
   :ret any?)
 
+(defn tty?
+  "Return true if the file descriptor numbered with fd-num is a tty"
+  [fd-num]
+  (js/PLANCK_ISATTY fd-num))
+
+(s/fdef tty?
+  :args (s/cat :fd-num (s/and integer? pos?)))
+
 ;; Ensure planck.io and planck.http are loaded so that their
 ;; facilities are available
 (#'repl/side-load-ns 'planck.http)

--- a/planck-cljs/src/planck/core.cljs
+++ b/planck-cljs/src/planck/core.cljs
@@ -495,14 +495,6 @@
   :args (s/cat :s string?)
   :ret any?)
 
-(defn tty?
-  "Return true if the file descriptor numbered with fd-num is a tty"
-  [fd-num]
-  (js/PLANCK_ISATTY fd-num))
-
-(s/fdef tty?
-  :args (s/cat :fd-num (s/and integer? pos?)))
-
 ;; Ensure planck.io and planck.http are loaded so that their
 ;; facilities are available
 (#'repl/side-load-ns 'planck.http)

--- a/planck-cljs/src/planck/io.cljs
+++ b/planck-cljs/src/planck/io.cljs
@@ -552,6 +552,11 @@
   :args (s/cat :input any? :output any? :opts (s/* any?))
   :ret nil?)
 
+(def ^:private stdio->fd
+  {planck.core/*in*  0
+   cljs.core/*out*   1
+   planck.core/*err* 2})
+
 (defn ^boolean tty?
   "Returns true if x is a file descriptor associated with a terminal,
   or x is either a Reader/Writer among *in*, *out*, or *err* which is
@@ -560,12 +565,9 @@
   Returns false if x is a file descriptor, *in*, *out*, or *err* and
   not associated with a terminal, or an invalid file descriptor."
   [x]
-  (let [stdio->fd {planck.core/*in*  0
-                   cljs.core/*out*   1
-                   planck.core/*err* 2}]
-    (-> (if-let [fd (stdio->fd x)] fd x)
-        js/PLANCK_ISATTY
-        boolean)))
+  (-> (if-let [fd (stdio->fd x)] fd x)
+      js/PLANCK_ISATTY
+      boolean))
 
 (s/fdef tty?
   :args (s/cat :x (s/or :fd-num (s/and integer? (complement neg?))

--- a/planck-cljs/src/planck/io.cljs
+++ b/planck-cljs/src/planck/io.cljs
@@ -552,6 +552,30 @@
   :args (s/cat :input any? :output any? :opts (s/* any?))
   :ret nil?)
 
+(defn tty?
+  "Returns true if x is a file descriptor associated with a terminal,
+  or x is either a Reader/Writer among *in*, *out*, or *err* which is
+  associated with a terminal.
+
+  Returns false if x is a file descriptor, *in*, *out*, or *err* and
+  not associated with a terminal.
+
+  Returns nil otherwise."
+  [x]
+  (when-let [fd (cond-> x
+                  (not (and (integer? x) (>= x 0)))
+                  {planck.core/*in*  0
+                   cljs.core/*out*   1
+                   planck.core/*err* 2})]
+    (js/PLANCK_ISATTY fd)))
+
+(s/fdef tty?
+  :args (s/cat :x (s/or :fd-num (s/and integer? (complement neg?))
+                        :reader #(implements? planck.core/IReader %)
+                        :writer #(implements? planck.core/IWriter %)))
+  :ret (s/or :tty? boolean?
+             :invalid nil?))
+
 ;; These have been moved
 (def ^:deprecated read-line planck.core/read-line)
 (def ^:deprecated slurp planck.core/slurp)

--- a/planck-cljs/src/planck/io.cljs
+++ b/planck-cljs/src/planck/io.cljs
@@ -560,13 +560,12 @@
   Returns false if x is a file descriptor, *in*, *out*, or *err* and
   not associated with a terminal, or an invalid file descriptor."
   [x]
-  (boolean
-    (when-let [fd (cond-> x
-                    (not (and (integer? x) (>= x 0)))
-                    {planck.core/*in*  0
-                     cljs.core/*out*   1
-                     planck.core/*err* 2})]
-      (js/PLANCK_ISATTY fd))))
+  (let [stdio->fd {planck.core/*in*  0
+                   cljs.core/*out*   1
+                   planck.core/*err* 2}]
+    (-> (if-let [fd (stdio->fd x)] fd x)
+        js/PLANCK_ISATTY
+        boolean)))
 
 (s/fdef tty?
   :args (s/cat :x (s/or :fd-num (s/and integer? (complement neg?))

--- a/planck-cljs/src/planck/io.cljs
+++ b/planck-cljs/src/planck/io.cljs
@@ -552,29 +552,27 @@
   :args (s/cat :input any? :output any? :opts (s/* any?))
   :ret nil?)
 
-(defn tty?
+(defn ^boolean tty?
   "Returns true if x is a file descriptor associated with a terminal,
   or x is either a Reader/Writer among *in*, *out*, or *err* which is
   associated with a terminal.
 
   Returns false if x is a file descriptor, *in*, *out*, or *err* and
-  not associated with a terminal.
-
-  Returns nil otherwise."
+  not associated with a terminal, or an invalid file descriptor."
   [x]
-  (when-let [fd (cond-> x
-                  (not (and (integer? x) (>= x 0)))
-                  {planck.core/*in*  0
-                   cljs.core/*out*   1
-                   planck.core/*err* 2})]
-    (js/PLANCK_ISATTY fd)))
+  (boolean
+    (when-let [fd (cond-> x
+                    (not (and (integer? x) (>= x 0)))
+                    {planck.core/*in*  0
+                     cljs.core/*out*   1
+                     planck.core/*err* 2})]
+      (js/PLANCK_ISATTY fd))))
 
 (s/fdef tty?
   :args (s/cat :x (s/or :fd-num (s/and integer? (complement neg?))
                         :reader #(implements? planck.core/IReader %)
                         :writer #(implements? planck.core/IWriter %)))
-  :ret (s/or :tty? boolean?
-             :invalid nil?))
+  :ret boolean?)
 
 ;; These have been moved
 (def ^:deprecated read-line planck.core/read-line)

--- a/planck-cljs/test/planck/io_test.cljs
+++ b/planck-cljs/test/planck/io_test.cljs
@@ -78,10 +78,10 @@
       (is (boolean? (planck.io/tty? planck.core/*in*)))
       (is (boolean? (planck.io/tty? *out*)))
       (is (boolean? (planck.io/tty? planck.core/*err*)))
-      (is (nil? (planck.io/tty? nil)))
-      (is (nil? (planck.io/tty? -1)))
-      (is (nil? (planck.io/tty? 99999999999999999)))
-      (is (nil? (planck.io/tty? (planck.io/reader regular-file)))))))
+      (is (= false (planck.io/tty? nil)))
+      (is (= false (planck.io/tty? -1)))
+      (is (= false (planck.io/tty? 99999999999999999)))
+      (is (= false (planck.io/tty? (planck.io/reader regular-file)))))))
 
 (deftest coercions
   (testing "as-file coerceions"

--- a/planck-cljs/test/planck/io_test.cljs
+++ b/planck-cljs/test/planck/io_test.cljs
@@ -71,7 +71,17 @@
       (is (= true  (planck.io/exists? hidden-directory)))
       (is (= true  (planck.io/hidden-file? hidden-directory)))
       (is (= false (planck.io/regular-file? hidden-directory)))
-      (is (= false (planck.io/symbolic-link? hidden-directory))))))
+      (is (= false (planck.io/symbolic-link? hidden-directory)))
+      (is (boolean? (planck.io/tty? 0)))
+      (is (boolean? (planck.io/tty? 1)))
+      (is (boolean? (planck.io/tty? 2)))
+      (is (boolean? (planck.io/tty? planck.core/*in*)))
+      (is (boolean? (planck.io/tty? *out*)))
+      (is (boolean? (planck.io/tty? planck.core/*err*)))
+      (is (nil? (planck.io/tty? nil)))
+      (is (nil? (planck.io/tty? -1)))
+      (is (nil? (planck.io/tty? 99999999999999999)))
+      (is (nil? (planck.io/tty? (planck.io/reader regular-file)))))))
 
 (deftest coercions
   (testing "as-file coerceions"

--- a/site/src/planck-io.md
+++ b/site/src/planck-io.md
@@ -38,6 +38,7 @@ _Vars_
 [regular-file?](#regular-file?)<br/>
 [resource](#resource)<br/>
 [symbolic-link?](#symbolic-link?)<br/>
+[tty?](#tty?)<br/>
 [writer](#writer)<br/>
    
 ## Protocols
@@ -298,6 +299,15 @@ Checks if `f` is a symbolic link.
 Spec<br/>
  _args_: `(cat :f (or :string string? :file file?))`<br/>
  _ret_: `boolean?`<br/>
+
+### <a name="tty?"></a>tty?
+`([x])`
+
+Checks if `x` is a file descriptor associated with a terminal. `x` may be a file descriptor number or one of `planck.core/*in*`, `cljs.core/*out*` or `planck.core/*err*`.
+
+Spec<br/>
+_x_: `(or :fd-num (and integer? (complement neg?)) :reader #(implements? planck.core/IReader %) :writer #(implements? planck.core/IWriter %))`<br/>
+_ret_: `boolean?`<br/>
 
 ### <a name="writer"></a>writer
 `([x & opts])`


### PR DESCRIPTION
Because planck is useful in scripting contexts, it may be executed sometimes in a pipeline and sometimes not. It would be useful to be able to detect whether stdin/stdout is a tty or not, in order to adapt script behavior.

Example use case: I may want a script that:
- reads input lines (via `read-line`, say) if there is an upstream pipe
- or else simply prints a help message if there is no upstream pipe.

Currently in planck, there seems to be no builtin way to detect stdin being a tty, so such a script running outside a pipe, that expects to read lines from stdin, will hang until there is interactive user input at `read-line`.

```
$ cat ./echo.cljs
#!/usr/bin/env plk
(require 'planck.core)
(println (planck.core/read-line))
```
Fine downstream of a pipe:
```
$ echo foo | ./echo.cljs
foo
```
Waits without a pipe:
```
$ ./echo.cljs

```
... until I type a line of input:
```
$ ./echo.cljs
foo
foo
```
(I'd rather have `$ ./echo.cljs` print a help message, say.)

In essence, I am looking for something capable of this:

```
$ cat ./is-stdin-tty.cljs
#!/usr/bin/env plk
(require 'planck.core)
(println (planck.core/tty? 0))
```
```
$ echo foo | ./is-stdin-tty.cljs
false
```
```
$ ./is-stdin-tty.cljs
true
```

For now, one workaround is to use a bash trampoline to execute `test -t 0` and pass that in via `*command-line-args*` to the planck script. e.g.

```
$ cat ./is-stdin-tty-bash.cljs
#!/usr/bin/env bash
#_(
  exec plk "$0" "$(test -t 0 && echo true || echo false)"
)
(require 'planck.core)
(println (first planck.core/*command-line-args*))

```

But it would be nicer to have access to `isatty` from `<unistd.h>` and gain functionality similar to Python's [`os.isatty`](https://docs.python.org/3/library/os.html#os.isatty) or Node's [`TTY.isatty`](https://nodejs.org/api/tty.html#tty_tty_isatty_fd).

This PR is a proof-of-concept implementation for discussion. It adds a `planck.core/tty?` function as in the `is-stdin-tty.cljs` example above.

Have I missed some other way of achieving this? Is it reasonable to expect a builtin function for this?