### PR TITLE
Make minor improvements to clean script and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ build-envs/*/*-cloudimg-console.log
 .cpcache
 .planck_cache
 /planck-man/plk.1
+*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Added
+- Add -keep-gcl option to the clean script
+- Ignore `*.swp` files
+
 ## [2.22.0] - 2019-04-06
 ### Added
 - Add `planck.core/with-in-str` ([#873](https://github.com/planck-repl/planck/issues/873))

--- a/script/clean
+++ b/script/clean
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    --keep-gcl)
+      export KEEP_GCL=1
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 if [ "${VERBOSE_BUILD:-0}" == "1" ]; then
   set -x
 fi
@@ -14,8 +27,10 @@ cd ..
 
 # GCL
 if [ -z "$BUILD_PPA" ]; then
-    rm -rf planck-cljs/lib/closure
-    rm -rf planck-cljs/lib/third_party
+    if ! [ "${KEEP_GCL:-0}" == "1" ]; then
+        rm -rf planck-cljs/lib/closure
+        rm -rf planck-cljs/lib/third_party
+    fi
     rm -f planck-cljs/src/planck/bundle/gcl.cljs
     rm -rf planck-cljs/src/planck/bundle
 fi

--- a/script/get-closure-library
+++ b/script/get-closure-library
@@ -4,11 +4,8 @@ if [ "${VERBOSE_BUILD:-0}" == "1" ]; then
   set -x
 fi
 
-if [ -d planck-cljs/lib/closure ]; then
-  exit
-fi
-
-mkdir -p planck-cljs/lib
+if ! [ -d planck-cljs/lib/closure ]; then
+  mkdir -p planck-cljs/lib
 cd planck-cljs/lib
 echo "Fetching Google Closure Library..."
 curl --retry 3 -LO -s https://github.com/google/closure-library/archive/v$GCL_RELEASE.zip || { echo "Download failed."; exit 1; }
@@ -19,6 +16,7 @@ echo "Cleaning up Google Closure Library archive..."
 rm -rf closure-library-$GCL_RELEASE
 rm v$GCL_RELEASE.zip
 cd ../..
+fi
 
 mkdir -p planck-cljs/src/planck/bundle
 output=planck-cljs/src/planck/bundle/gcl.cljs


### PR DESCRIPTION
This PR makes two minor improvements:

1. adds `--keep-gcl` option to the clean script;
2. adds `*.swp` to `.gitignore`.

The first improvement was desired because I was finding the downloading of the GCL from the official GitHub repo was taking a long time when compiling.

The second improvement is helpful for Vim users. 