### PR TITLE
Switch strncpy() to memcpy()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file. This change
 - Add -keep-gcl option to the clean script
 - Ignore `*.swp` files
 
+### Fixed
+- Switch `strncpy` to `memcpy` to avoid GCC warning
+
 ## [2.22.0] - 2019-04-06
 ### Added
 - Add `planck.core/with-in-str` ([#873](https://github.com/planck-repl/planck/issues/873))

--- a/planck-c/str.c
+++ b/planck-c/str.c
@@ -29,8 +29,8 @@ char *str_concat(const char *s1, const char *s2) {
     char *s = malloc(len * sizeof(char));
 
     if (s) {
-        strncpy(s, s1, l1);
-        strncpy(s + l1, s2, l2 + 1);
+        memcpy(s, s1, l1);
+        memcpy(s + l1, s2, l2 + 1);
     }
     return s;
 }


### PR DESCRIPTION
GCC 8 introduces a new warning if `strncpy()` is used and it is possible that the length of the source string is greater than the length of the destination string (this will result in the resulting string being non-null terminated). This warning can be avoided by using `memcpy()`.