### PR TITLE
Fix -e arguments affecting *1, *2, *3 and *e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file. This change
 - Add -keep-gcl option to the clean script
 - Ignore `*.swp` files
 
+### Fixed
+- `-e` affects `*1`, `*2`, `*3` ([#659](https://github.com/planck-repl/planck/issues/659))
+
 ## [2.22.0] - 2019-04-06
 ### Added
 - Add `planck.core/with-in-str` ([#873](https://github.com/planck-repl/planck/issues/873))

--- a/planck-cljs/src/planck/repl.cljs
+++ b/planck-cljs/src/planck/repl.cljs
@@ -2141,7 +2141,7 @@
       (cond 
         (= "path" source-type) (process-execute-path source-value (assoc opts :source-path source-value))
         (= "text" source-type) (let [source-text source-value
-                                                 first-form  (eof-guarded-read source-text)]
+                                     first-form  (eof-guarded-read source-text)]
                                   (when (not= eof first-form)
                                     (let [expression-form (and expression? first-form)]
                                       (if (repl-special? expression-form)

--- a/planck-cljs/src/planck/repl.cljs
+++ b/planck-cljs/src/planck/repl.cljs
@@ -106,7 +106,7 @@
        :doc "*pprint-results* controls whether Planck REPL results are pretty printed.
   If it is bound to logical false, results are printed in a plain fashion.
   Otherwise, results are pretty printed."}
- *pprint-results* true)
+  *pprint-results* true)
 
 (def ^:private ^:const expression-name "Expression")
 (def ^:private could-not-eval-expr (str "Could not eval " expression-name))
@@ -949,7 +949,7 @@
 (defn- js-eval
   [source source-url]
   #_(when (:verbose @app-env)
-     (println-verbose (str "Evaluating JavaScript:\n" source)))
+      (println-verbose (str "Evaluating JavaScript:\n" source)))
   (if source-url
     (let [exception (js/PLANCK_EVAL source source-url)]
       (when exception
@@ -1989,12 +1989,12 @@
 
 (defn- process-1-2-3
   [expression-form value]
-  (when-not
-   (or ('#{*1 *2 *3 *e} expression-form)
-       (ns-form? expression-form))
-   (set! *3 *2)
-   (set! *2 *1)
-   (set! *1 value)))
+  (when (and (:repl @app-env)
+             (not ('#{*1 *2 *3 *e} expression-form))
+             (not (ns-form? expression-form)))
+    (set! *3 *2)
+    (set! *2 *1)
+    (set! *1 value)))
 
 (defn- cache-source-fn
   [source-text]
@@ -2115,8 +2115,7 @@
                 (when (or print-nil-expression?
                           (not (nil? value)))
                   (print-value value {::as-code? (macroexpand-form? expression-form)}))
-                (when (:repl @app-env)
-                  (process-1-2-3 expression-form value))
+                (process-1-2-3 expression-form value)
                 (when (def-form? expression-form)
                   (let [{:keys [ns name]} (meta value)]
                     (swap! st assoc-in [::ana/namespaces ns :defs name ::repl-entered-source] source-text)))

--- a/planck-cljs/src/planck/repl.cljs
+++ b/planck-cljs/src/planck/repl.cljs
@@ -106,7 +106,7 @@
        :doc "*pprint-results* controls whether Planck REPL results are pretty printed.
   If it is bound to logical false, results are printed in a plain fashion.
   Otherwise, results are pretty printed."}
-*pprint-results* true)
+ *pprint-results* true)
 
 (def ^:private ^:const expression-name "Expression")
 (def ^:private could-not-eval-expr (str "Could not eval " expression-name))
@@ -949,7 +949,7 @@
 (defn- js-eval
   [source source-url]
   #_(when (:verbose @app-env)
-    (println-verbose (str "Evaluating JavaScript:\n" source)))
+     (println-verbose (str "Evaluating JavaScript:\n" source)))
   (if source-url
     (let [exception (js/PLANCK_EVAL source source-url)]
       (when exception
@@ -1992,9 +1992,9 @@
   (when-not
    (or ('#{*1 *2 *3 *e} expression-form)
        (ns-form? expression-form))
-    (set! *3 *2)
-    (set! *2 *1)
-    (set! *1 value)))
+   (set! *3 *2)
+   (set! *2 *1)
+   (set! *1 value)))
 
 (defn- cache-source-fn
   [source-text]
@@ -2115,7 +2115,8 @@
                 (when (or print-nil-expression?
                           (not (nil? value)))
                   (print-value value {::as-code? (macroexpand-form? expression-form)}))
-                (process-1-2-3 expression-form value)
+                (when (:repl @app-env)
+                  (process-1-2-3 expression-form value))
                 (when (def-form? expression-form)
                   (let [{:keys [ns name]} (meta value)]
                     (swap! st assoc-in [::ana/namespaces ns :defs name ::repl-entered-source] source-text)))
@@ -2138,15 +2139,15 @@
               cljs/*load-fn*   load-fn
               cljs/*eval-fn*   (get-eval-fn)
               tags/*cljs-data-readers* (data-readers)]
-      (if-not (= "text" source-type)
-        (process-execute-path source-value (assoc opts :source-path source-value))
-        (let [source-text source-value
-              first-form  (eof-guarded-read source-text)]
-          (when (not= eof first-form)
-            (let [expression-form (and expression? first-form)]
-              (if (repl-special? expression-form)
-                (process-repl-special expression-form opts)
-                (process-execute-source source-text expression-form opts)))))))))
+      (cond 
+        (= "path" source-type) (process-execute-path source-value (assoc opts :source-path source-value))
+        (= "text" source-type) (let [source-text source-value
+                                                 first-form  (eof-guarded-read source-text)]
+                                  (when (not= eof first-form)
+                                    (let [expression-form (and expression? first-form)]
+                                      (if (repl-special? expression-form)
+                                        (process-repl-special expression-form opts)
+                                        (process-execute-source source-text expression-form opts)))))))))
 
 (defn- ^:export execute
   [source expression? print-nil-expression? set-ns theme-id session-id]

--- a/planck-cljs/src/planck/repl.cljs
+++ b/planck-cljs/src/planck/repl.cljs
@@ -106,7 +106,7 @@
        :doc "*pprint-results* controls whether Planck REPL results are pretty printed.
   If it is bound to logical false, results are printed in a plain fashion.
   Otherwise, results are pretty printed."}
-  *pprint-results* true)
+*pprint-results* true)
 
 (def ^:private ^:const expression-name "Expression")
 (def ^:private could-not-eval-expr (str "Could not eval " expression-name))
@@ -949,7 +949,7 @@
 (defn- js-eval
   [source source-url]
   #_(when (:verbose @app-env)
-      (println-verbose (str "Evaluating JavaScript:\n" source)))
+    (println-verbose (str "Evaluating JavaScript:\n" source)))
   (if source-url
     (let [exception (js/PLANCK_EVAL source source-url)]
       (when exception

--- a/planck-cljs/src/planck/repl.cljs
+++ b/planck-cljs/src/planck/repl.cljs
@@ -2138,15 +2138,15 @@
               cljs/*load-fn*   load-fn
               cljs/*eval-fn*   (get-eval-fn)
               tags/*cljs-data-readers* (data-readers)]
-      (cond 
-        (= "path" source-type) (process-execute-path source-value (assoc opts :source-path source-value))
-        (= "text" source-type) (let [source-text source-value
-                                     first-form  (eof-guarded-read source-text)]
-                                  (when (not= eof first-form)
-                                    (let [expression-form (and expression? first-form)]
-                                      (if (repl-special? expression-form)
-                                        (process-repl-special expression-form opts)
-                                        (process-execute-source source-text expression-form opts)))))))))
+      (case source-type
+        "path" (process-execute-path source-value (assoc opts :source-path source-value))
+        "text" (let [source-text source-value
+                     first-form  (eof-guarded-read source-text)]
+                  (when (not= eof first-form)
+                    (let [expression-form (and expression? first-form)]
+                      (if (repl-special? expression-form)
+                        (process-repl-special expression-form opts)
+                        (process-execute-source source-text expression-form opts)))))))))
 
 (defn- ^:export execute
   [source expression? print-nil-expression? set-ns theme-id session-id]


### PR DESCRIPTION
Planck's evaluation logic treated evaluation of text entered at a REPL and evaluation of arguments to `-e` the same. This resulted in the result variables (`*1`, `*2`, `*3`) being set in both cases. As noted in #659, this is not the behaviour of Clojure. This commit fixes #659 by testing whether the evaluation is occurring in a REPL environment.