### PR TITLE
Fix empty lines not being processed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. This change
 
 ### Fixed
 - Switch `strncpy` to `memcpy` to avoid GCC warning
+- Backslash return return should produce "\n" ([661](https://github.com/planck-repl/planck/issues/661))
 
 ## [2.22.0] - 2019-04-06
 ### Added

--- a/planck-c/repl.c
+++ b/planck-c/repl.c
@@ -334,10 +334,14 @@ void run_cmdline_loop(repl_t *repl) {
 
         // If the input is small process each line separately here
         // so that things like brace highlighting work properly.
-        // But for large input, let process line more efficiently
-        // handle the input.
+        // But for large input, let process_line() more efficiently
+        // handle the input. The initial case is for a new line (the
+        // new itself is not part of input_line).
         bool break_out = false;
-        if (strlen(input_line) < 16384) {
+        if (repl->input != NULL & strlen(input_line) == 0) {
+            repl->indent_space_count = 0;
+            break_out = process_line(repl, input_line, false);
+        } else if (strlen(input_line) < 16384) {
             char *tokenize = strdup(input_line);
             char *saveptr;
             char *token = strtok_r(tokenize, "\n", &saveptr);


### PR DESCRIPTION
As described in #661, Planck has a bug where an empty line after a backslash is not processed and so does not produce the correct output (a newline character). This was due to the fact a newline by itself appears to the REPL as an empty string. This PR detects that and processes it properly. This fixes #661.