### PR TITLE
tty? spec refers to planck.core/IWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- `tty?` spec refers to `planck.core/IWriter` ([#928](https://github.com/planck-repl/planck/issues/928))
 
 ## [2.23.0] - 2019-05-19
 ### Added

--- a/planck-cljs/src/planck/io.cljs
+++ b/planck-cljs/src/planck/io.cljs
@@ -573,7 +573,7 @@
 (s/fdef tty?
   :args (s/cat :x (s/or :fd-num (s/and integer? (complement neg?))
                         :reader #(implements? planck.core/IReader %)
-                        :writer #(implements? planck.core/IWriter %)))
+                        :writer #(implements? IWriter %)))
   :ret boolean?)
 
 ;; These have been moved


### PR DESCRIPTION
Fixes #928