### PR TITLE
io/reader on http follow redirects by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file. This change
 ### Added
 - Native temp file and dir facilities ([#934](https://github.com/planck-repl/planck/issues/934)
 
+### Changed
+- `io/reader` on http follow redirects by default ([#937](https://github.com/planck-repl/planck/issues/937))
+
 ### Fixed
 - `tty?` spec refers to `planck.core/IWriter` ([#928](https://github.com/planck-repl/planck/issues/928))
 

--- a/planck-cljs/src/planck/io.cljs
+++ b/planck-cljs/src/planck/io.cljs
@@ -134,7 +134,7 @@
 
 (defn- make-http-uri-reader
   [uri opts]
-  (#'planck.core/make-string-reader (:body (http/get (str uri) {}))))
+  (#'planck.core/make-string-reader (:body (http/get (str uri) (merge {:follow-redirects true} opts)))))
 
 (defn- make-http-uri-writer
   [uri opts]

--- a/planck-cljs/test/planck/core_test.cljs
+++ b/planck-cljs/test/planck/core_test.cljs
@@ -173,3 +173,7 @@
 
 (deftest with-in-str-test
   (is (= "34" (planck.core/with-in-str "34\n35" (planck.core/read-line)))))
+
+(deftest slurp-follow-redirects-by-default
+  (is (string/includes? (planck.core/slurp "http://planck-repl.org") "ClojureScript REPL"))
+  (is (string/includes? (planck.core/slurp "http://planck-repl.org" :follow-redirects false) "Moved Permanently")))


### PR DESCRIPTION
Fixes #937

Follows redirects by default, but allows users to disable