### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This change
 ## [Unreleased]
 ### Fixed
 - `tty?` spec refers to `planck.core/IWriter` ([#928](https://github.com/planck-repl/planck/issues/928))
+- Update dependencies ([#940](https://github.com/planck-repl/planck/issues/940), [#941](https://github.com/planck-repl/planck/issues/941), [#942]((https://github.com/planck-repl/planck/issues/942))
 
 ## [2.23.0] - 2019-05-19
 ### Added

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -111,8 +111,8 @@ Planck ships with many of the deps that are available to conventional ClojureScr
 
 In addition, Planck ships with these libraries:
 
-* [Fipp](https://github.com/brandonbloom/fipp) 0.6.14
-* [transit-cljs](https://github.com/cognitect/transit-cljs) 0.8.248
+* [Fipp](https://github.com/brandonbloom/fipp) 0.6.18
+* [transit-cljs](https://github.com/cognitect/transit-cljs) 0.8.256
 
 Note that bundled dependencies, which includes the core ClojureScript compiler namespaces, are loaded in preference to dependencies specified via `deps.edn`, `-c` / `-​-​classpath`, `-D` / `-​-​dependencies`, or `PLANCK_CLASSPATH`.
 

--- a/planck-cljs/deps.edn
+++ b/planck-cljs/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojurescript {:mvn/version "1.10.520"}
-        org.clojure/test.check {:mvn/version "0.10.0-alpha3"}
-        com.cognitect/transit-cljs {:mvn/version "0.8.248"}
-        fipp {:mvn/version "0.6.14"}
+        org.clojure/test.check {:mvn/version "0.10.0-alpha4"}
+        com.cognitect/transit-cljs {:mvn/version "0.8.256"}
+        fipp {:mvn/version "0.6.18"}
         malabarba/lazy-map {:mvn/version "1.3"}
-        cljsjs/parinfer {:mvn/version "1.8.1-0"}
+        cljsjs/parinfer {:mvn/version "3.11.0-0"}
         cljsjs/long {:mvn/version "3.0.3-1"}}}

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :source-paths ["planck-cljs/src"]
   :dependencies [[org.clojure/clojurescript "1.10.520"]
-                 [fipp "0.6.14"]
+                 [fipp "0.6.18"]
                  [malabarba/lazy-map "1.3"]
-                 [com.cognitect/transit-cljs "0.8.248"]
+                 [com.cognitect/transit-cljs "0.8.256"]
                  [cljsjs/parinfer "1.8.1-0"]])

--- a/script/get-tcheck
+++ b/script/get-tcheck
@@ -5,6 +5,6 @@ if [ "${VERBOSE_BUILD:-0}" == "1" ]; then
 fi
 
 mkdir -p lib
-if [ ! -f lib/test.check-0.10.0-alpha3.jar ]; then
-  cp ~/.m2/repository/org/clojure/test.check/0.10.0-alpha3/test.check-0.10.0-alpha3.jar lib/test.check-0.10.0-alpha3.jar
+if [ ! -f lib/test.check-0.10.0-alpha4.jar ]; then
+  cp ~/.m2/repository/org/clojure/test.check/0.10.0-alpha4/test.check-0.10.0-alpha4.jar lib/test.check-0.10.0-alpha4.jar
 fi

--- a/script/test-unit
+++ b/script/test-unit
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-"exec" "planck-c/build/planck" "--classpath=lib/test.check-0.10.0-alpha3.jar:lib/long-3.0.3-1.jar:planck-cljs/test" "--compile-opts" "@/compile-opts.edn" "$0" "$@"
+"exec" "planck-c/build/planck" "--classpath=lib/test.check-0.10.0-alpha4.jar:lib/long-3.0.3-1.jar:planck-cljs/test" "--compile-opts" "@/compile-opts.edn" "$0" "$@"
 (ns planck.unit-test
   (:require [cljs.test]
             [planck.test-runner]


### PR DESCRIPTION
This updates the following dependencies:

- cljsjs/parinfer to 3.11.0-0;
- fipp 0.6.18;
- test.check to 0.10.0-alpha4; and
- transit-cljs to 0.8.256.

This fixes #940, #941 and #942.