### PR TITLE
IO encoding should default to UTF-8 if unspecified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file. This change
 - `tty?` spec refers to `planck.core/IWriter` ([#928](https://github.com/planck-repl/planck/issues/928))
 - HTTP binary response includes trailing buffer ([#949](https://github.com/planck-repl/planck/issues/949))
 - Update dependencies ([#940](https://github.com/planck-repl/planck/issues/940), [#941](https://github.com/planck-repl/planck/issues/941), [#942]((https://github.com/planck-repl/planck/issues/942))
+- IO encoding should default to UTF-8 if unspecified ([#960](https://github.com/planck-repl/planck/issues/960))
+
 
 ## [2.23.0] - 2019-05-19
 ### Added

--- a/planck-cljs/src/planck/io.cljs
+++ b/planck-cljs/src/planck/io.cljs
@@ -78,6 +78,9 @@
     (as-url f)
     (as-file f)))
 
+(defn- encoding [opts]
+  (or (:encoding opts) "UTF-8"))
+
 (defprotocol IOFactory
   "Factory functions that create ready-to-use versions of the various stream
   types, on top of anything that can be unequivocally converted to the
@@ -160,7 +163,7 @@
 
   File
   (make-reader [file opts]
-    (let [file-descriptor (js/PLANCK_FILE_READER_OPEN (:path file) (:encoding opts))]
+    (let [file-descriptor (js/PLANCK_FILE_READER_OPEN (:path file) (encoding opts))]
       (check-file-descriptor file-descriptor file opts)
       (swap! open-file-reader-descriptors conj file-descriptor)
       (#'planck.core/->Reader
@@ -178,7 +181,7 @@
         (atom nil)
         (atom 0))))
   (make-writer [file opts]
-    (let [file-descriptor (js/PLANCK_FILE_WRITER_OPEN (:path file) (boolean (:append opts)) (:encoding opts))]
+    (let [file-descriptor (js/PLANCK_FILE_WRITER_OPEN (:path file) (boolean (:append opts)) (encoding opts))]
       (check-file-descriptor file-descriptor file opts)
       (swap! open-file-writer-descriptors conj file-descriptor)
       (#'planck.core/->Writer

--- a/planck-cljs/test/planck/io_test.cljs
+++ b/planck-cljs/test/planck/io_test.cljs
@@ -200,8 +200,7 @@
       (is (no-diff src dst))
       (io/copy (io/file src) (io/file dst))
       (is (no-diff src dst)))
-    ; Commented until https://github.com/planck-repl/planck/issues/951 is fixed
-    #_(testing "String -> OutputStream"
+    (testing "String -> OutputStream"
       (with-open [out (io/output-stream dst)]
         (io/copy content out))
       (is (no-diff src dst)))


### PR DESCRIPTION
Fixes #960