### PR TITLE
GCL lib analysis issue with ClojureScript master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. This change
 
 ### Fixed
 - Crash if writing large byte vector to output stream ([#1001](https://github.com/planck-repl/planck/issues/1001))
+- GCL lib analysis issue with ClojureScript master ([#1011](https://github.com/planck-repl/planck/issues/1011))
 
 ## [2.24.0] - 2019-07-25
 ### Added

--- a/planck-cljs/deps.edn
+++ b/planck-cljs/deps.edn
@@ -1,4 +1,5 @@
 {:deps {org.clojure/clojurescript {:mvn/version "1.10.520"}
+        org.clojure/google-closure-library {:mvn/version "0.0-20190213-2033d5d9"}
         org.clojure/test.check {:mvn/version "0.10.0-alpha4"}
         com.cognitect/transit-cljs {:mvn/version "0.8.256"}
         com.cognitect/transit-js {:mvn/version "0.8.861"}


### PR DESCRIPTION
Fixes #1011

This fixes the issue by simply causing the JVM compiler to have a version of GCL on the classpath which is closer to the one Planck ships with.

Ideally, in the future, Planck should ship with a version that is identical to the one that it puts on the JVM classpath. This would be good for the next ClojureScript compiler release because that release does type analysis of Closure libraries, which leads to additional type inference, and thus potentially different code gen.

To pull that off, we’d probably need to stop fetching the GCL ZIP from GitHub but instead only make use of the Clojure-built google-closure-library JAR for everything.