### PR TITLE
Using `set -e` in build scripts

### DIFF
--- a/script/build
+++ b/script/build
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e -o pipefail
 
 while [ $# -gt 0 ]
 do
@@ -40,7 +41,7 @@ if [ -z ${FAST_BUILD+set} ]; then
 fi
 
 #----------------------------------------------------
-# Exit if the last command failed, indicating 
+# If the last command failed, indicate
 # that there was a build failure
 #----------------------------------------------------
 checkCmdSuccess() {
@@ -50,6 +51,7 @@ checkCmdSuccess() {
         exit $CMD_RESULT 
     fi
 }
+trap checkCmdSuccess EXIT
 
 export GCC_RELEASE="20190301"
 export CLOSURE_JS_RELEASE=${GCC_RELEASE}.0.0
@@ -70,7 +72,6 @@ if [ -n "$NON_BUNDLED_SRC" ] || [ ! -d planck-c/build ] || [ $BUNDLE_SIZE -le 40
   cd planck-cljs
   echo "### Building planck-cljs"
   script/build
-  checkCmdSuccess
   cd ..
   
   # Remove any leftover macros files so that they will not be bundled
@@ -91,7 +92,6 @@ if [ -n "$NON_BUNDLED_SRC" ] || [ ! -d planck-c/build ] || [ $BUNDLE_SIZE -le 40
   echo "### Bundling ClojureScript artifacts for 1st stage"
   cd planck-cljs
   script/bundle
-  checkCmdSuccess
   cd ..
   
   echo "### Building 1st stage Planck binary"
@@ -101,16 +101,13 @@ if [ -n "$NON_BUNDLED_SRC" ] || [ ! -d planck-c/build ] || [ $BUNDLE_SIZE -le 40
   if [ ! -e Makefile ]
   then
      cmake .. > /dev/null
-     checkCmdSuccess
   fi
   make > /dev/null
-  checkCmdSuccess
   cd ../..
   
   echo "### AOT compiling macro namespaces"
   mkdir -p planck-cljs/out/macros-tmp
   planck-c/build/planck -sk planck-cljs/out/macros-tmp -e"(require 'cljs.analyzer)" -e"(do (set! cljs.analyzer/*cljs-warnings* (assoc cljs.analyzer/*cljs-warnings* :undeclared-var false)) nil)" -e "(require-macros 'planck.repl 'planck.core 'planck.shell 'planck.from.io.aviso.ansi 'clojure.template 'cljs.spec.alpha 'cljs.spec.test.alpha 'cljs.spec.gen.alpha 'cljs.test 'cljs.pprint 'cljs.analyzer.macros 'cljs.compiler.macros 'cljs.env.macros)"
-  checkCmdSuccess
 
   mv planck-cljs/out/macros-tmp/planck_SLASH_repl\$macros.js planck-cljs/out/planck/repl\$macros.js
   mv planck-cljs/out/macros-tmp/planck_SLASH_repl\$macros.cache.json planck-cljs/out/planck/repl\$macros.cache.json
@@ -157,7 +154,6 @@ if [ -n "$NON_BUNDLED_SRC" ] || [ ! -d planck-c/build ] || [ $BUNDLE_SIZE -le 40
   echo "### Bundling ClojureScript artifacts for 2nd stage"
   cd planck-cljs
   script/bundle
-  checkCmdSuccess
   cd ..
 
   echo "### Building 2nd stage Planck binary"
@@ -166,7 +162,6 @@ fi
 
 cd planck-c/build
 make > /dev/null
-checkCmdSuccess
 cd ../..
 
 cp planck-man/planck.1 planck-man/plk.1

--- a/script/build-sandbox
+++ b/script/build-sandbox
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -e -o pipefail
+
 export VERBOSE_BUILD=1
 export SANDBOX_BUILD=1
 export CLJ_CONFIG=clj-config

--- a/script/clean
+++ b/script/clean
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e -o pipefail
 
 while [ $# -gt 0 ]
 do

--- a/script/get-build-cache
+++ b/script/get-build-cache
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e -o pipefail
 
 if [ "${VERBOSE_BUILD:-0}" == "1" ]; then
   set -x

--- a/script/get-cljsjs-long
+++ b/script/get-cljsjs-long
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
+set -e -o pipefail
 
 if [ "${VERBOSE_BUILD:-0}" == "1" ]; then
   set -x
 fi
 
 mkdir -p lib
-if [ ! -f lib/long-3.0.3-1.jar ]; then
-  cp ~/.m2/repository/cljsjs/long/3.0.3-1/long-3.0.3-1.jar lib/long-3.0.3-1.jar
+version=3.0.3-1
+if [ ! -f lib/long-$version.jar ]; then
+  cp ~/.m2/repository/cljsjs/long/$version/long-$version.jar lib/long-$version.jar
 fi

--- a/script/get-closure-compiler
+++ b/script/get-closure-compiler
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e -o pipefail
 
 if [ "${VERBOSE_BUILD:-0}" == "1" ]; then
   set -x

--- a/script/get-closure-library
+++ b/script/get-closure-library
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e -o pipefail
 
 if [ "${VERBOSE_BUILD:-0}" == "1" ]; then
   set -x

--- a/script/get-tcheck
+++ b/script/get-tcheck
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
+set -e -o pipefail
 
 if [ "${VERBOSE_BUILD:-0}" == "1" ]; then
   set -x
 fi
 
 mkdir -p lib
-if [ ! -f lib/test.check-0.10.0-alpha4.jar ]; then
-  cp ~/.m2/repository/org/clojure/test.check/0.10.0-alpha4/test.check-0.10.0-alpha4.jar lib/test.check-0.10.0-alpha4.jar
+version=0.10.0-alpha4
+if [ ! -f lib/test.check-$version.jar ]; then
+  cp ~/.m2/repository/org/clojure/test.check/$version/test.check-$version.jar lib/test.check-$version.jar
 fi


### PR DESCRIPTION
Thanks so much for making planck!

This PR tweaks the build scripts to use `set -e`, which causes bash to exit upon first error (also, `set -o pipefail`, which does the same if any part of a bash pipeline fails).

`script/build` was tweaked so that the `checkCmdSuccess` function is now run after _any_ failure, via bash signal trap upon exit.

As it happens, I had forgotten to install `git` in my chroot when I tested this, so I got to see a failure:

```
$ script/build --version
...
+ git update-index --assume-unchanged ../planck-c/bundle.c
script/bundle: line 234: git: command not found
+ checkCmdSuccess
+ CMD_RESULT=127
+ '[' 127 '!=' 0 ']'
+ echo 'Build Failed.'
Build Failed.
+ exit 127
```

(without `--verbose`, this would have been:)

```
script/bundle: line 234: git: command not found
Build Failed.
```

I've read through the scripts and it doesn't look like any of them were relying on any _continue-despite-error_ behavior, so I believe these changes to be safe.

I have run `script/build` on my local machine to test this, but I'm not 100% sure that covers all of the script code paths.

Additionally, a couple of `$version` bash vars were extracted (in `get-tcheck` and `get-cljsjs-long`).

This fixes #1026.
