### PR TITLE
ci: bump unbuntu to 22.04

### DIFF
--- a/.github/workflows/build_test_planck.yml
+++ b/.github/workflows/build_test_planck.yml
@@ -23,7 +23,7 @@ jobs:
           script/test
 
   build_ubuntu:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
We were not having success with 20.04 (#1087), based on past tests, I'm
thinking we might be good on 22.04.