### PR TITLE
ci: config tweaks

### DIFF
--- a/.github/workflows/build_test_planck.yml
+++ b/.github/workflows/build_test_planck.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3.0.2
 
+      - uses: actions/setup-java@v3.4.1
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+
       - name: Install Clojure
         uses: DeLaGuardo/setup-clojure@9.4
         with:

--- a/.github/workflows/build_test_planck.yml
+++ b/.github/workflows/build_test_planck.yml
@@ -11,11 +11,12 @@ jobs:
     runs-on: macos-11
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.0.2
 
       - name: Install Clojure
-        run: |
-          brew install clojure/tools/clojure
+        uses: DeLaGuardo/setup-clojure@9.4
+        with:
+          cli: latest
 
       - name: Build and Test Planck
         run: | 
@@ -26,21 +27,22 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.0.2
 
-      - uses: actions/setup-java@v2.5.0
+      - uses: actions/setup-java@v3.4.1
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
 
-      - uses: DeLaGuardo/setup-clojure@master
+      - name: Install Clojure
+        uses: DeLaGuardo/setup-clojure@9.4
         with:
-            cli: latest
+          cli: latest
 
       - name: Install deps
         run: |
-            sudo apt-get update
-            sudo apt-get install -y libjavascriptcoregtk-4.0 libglib2.0-dev libzip-dev libcurl4-gnutls-dev libicu-dev unzip
+          sudo apt-get update
+          sudo apt-get install -y libjavascriptcoregtk-4.0 libglib2.0-dev libzip-dev libcurl4-gnutls-dev libicu-dev unzip
 
       - name: Build and Test Planck
         run: | 


### PR DESCRIPTION
- adopt jdk -> temurin jdk (adopt is deprecated)
- use setup-clojure on macos
- bump gh actions to current versions

Closes #1097