### PR TITLE
Exit script/build immediately upon error

### DIFF
--- a/script/build
+++ b/script/build
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 while [ $# -gt 0 ]
 do
   case "$1" in

--- a/script/get-closure-library
+++ b/script/get-closure-library
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 if [ "${VERBOSE_BUILD:-0}" == "1" ]; then
   set -x
 fi


### PR DESCRIPTION
Without this change, errors in the build process do not cancel the build, leading to additional errors that can obscure the cause of the build failure.

When I attempted to build planck locally lacking the `jar` command, the following happened:

```
planck $ ./script/build
Creating an optimized build, using build cache to speed up build.
Specifying --fast skips optimizations and takes less than two minutes.
Fetching Google Closure Compiler...
Fetching Google Closure Library...
script/get-closure-library: line 17: jar: command not found
script/get-closure-library: line 23: jar: command not found
script/get-closure-library: line 37: cd: planck-cljs/lib/closure/goog: No such file or directory
script/get-closure-library: line 64: cd: planck-cljs/lib/third_party/closure/goog: No such file or directory
find: ‘./var/spool/cron/crontabs’: Permission denied
find: ‘./var/spool/cups’: Permission denied
find: ‘./var/spool/rsyslog’: Permission denied
find: ‘./var/spool/postfix/bounce’: Permission denied
...
```

It appears that after `jar` was missing, a `cd` command didn't work and it took me to the root directory, where further commands attempted to read unrelated directories.

With this change, the build errors immediately once `jar` fails:

```
planck $ ./script/build
Creating an optimized build, using build cache to speed up build.
Specifying --fast skips optimizations and takes less than two minutes.
Fetching Google Closure Compiler...
Fetching Google Closure Library...
script/get-closure-library: line 19: jar: command not found
planck $
```

This seems like preferable behavior to me, but it might lead to issues if other commands depended on the `build` script to continue through some types of errors. I'm open to alternative approaches to `set -e`.

It's also worth considering whether such a setting should be in every bash script, if it's considered an improvement.